### PR TITLE
ecuacion-splib-rest: Multiple expected api keys now accepted

### DIFF
--- a/ecuacion-splib-rest/src/main/java/jp/ecuacion/splib/rest/apikey/SplibApiKeyComparisonMode.java
+++ b/ecuacion-splib-rest/src/main/java/jp/ecuacion/splib/rest/apikey/SplibApiKeyComparisonMode.java
@@ -17,7 +17,7 @@ package jp.ecuacion.splib.rest.apikey;
 
 /**
  * Selects how the value returned by
- * {@link SplibApiKeyExpectedValueProvider#getExpectedValue} is compared against the
+ * {@link SplibApiKeyExpectedValueProvider#getExpectedValues} is compared against the
  * client-presented {@code X-Api-Key} header value.
  *
  * <p>Selected application-wide via {@code jp.ecuacion.splib.rest.api-key.mode} (default


### PR DESCRIPTION
- a javadoc bug fixed
