### PR TITLE
builtin rest controllers improved

### DIFF
--- a/ecuacion-splib-rest/src/main/java/jp/ecuacion/splib/rest/apikey/SplibBuiltinApiKeyAuthenticationFilter.java
+++ b/ecuacion-splib-rest/src/main/java/jp/ecuacion/splib/rest/apikey/SplibBuiltinApiKeyAuthenticationFilter.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2012 ecuacion.jp (info@ecuacion.jp)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.ecuacion.splib.rest.apikey;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import jp.ecuacion.lib.core.logging.DetailLogger;
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Authenticates requests under {@code /api/ecuacion-splib/key/**} using the {@code X-Api-Key}
+ * (and optional {@code X-Api-Key-Id}) request headers.
+ *
+ * <p>Parallels {@link SplibApiKeyAuthenticationFilter}, but is kept as a separate class backed by
+ *     {@link SplibBuiltinApiKeyExpectedValueProvider} so that {@code ecuacion-splib}'s own
+ *     built-in endpoints (e.g. {@code SystemErrorController}) are gated by a key set independent
+ *     of the application's own {@code /api/key/**} keys.</p>
+ *
+ * <p>All rejection paths (missing header, no {@link SplibBuiltinApiKeyExpectedValueProvider} bean
+ *     registered, no matching key, wrong key) return the same generic 401 response, so a caller
+ *     cannot distinguish a server misconfiguration from a wrong key. Details are logged
+ *     server-side only, and the presented key value itself is never logged.</p>
+ */
+public class SplibBuiltinApiKeyAuthenticationFilter extends OncePerRequestFilter {
+
+  /** Request header carrying the API key itself. Required on every request to this filter. */
+  public static final String HEADER_API_KEY = "X-Api-Key";
+
+  /**
+   * Request header carrying an optional key identifier, passed through to
+   * {@link SplibBuiltinApiKeyExpectedValueProvider#getExpectedValues} as-is. See that method's
+   * javadoc.
+   */
+  public static final String HEADER_API_KEY_ID = "X-Api-Key-Id";
+
+  /** The authority granted to a request that authenticates successfully via this filter. */
+  private static final String API_KEY_AUTHORITY = "ROLE_BUILTIN_API_KEY";
+
+  private final DetailLogger detailLog = new DetailLogger(this);
+
+  private final @Nullable SplibBuiltinApiKeyExpectedValueProvider expectedValueProvider;
+  private final SplibApiKeyComparisonMode comparisonMode;
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param expectedValueProvider the application-supplied provider, or {@code null} if the
+   *     application never registered one — every request is then rejected
+   * @param comparisonMode how to compare the presented key against the provider's return value
+   */
+  public SplibBuiltinApiKeyAuthenticationFilter(
+      @Nullable SplibBuiltinApiKeyExpectedValueProvider expectedValueProvider,
+      SplibApiKeyComparisonMode comparisonMode) {
+    this.expectedValueProvider = expectedValueProvider;
+    this.comparisonMode = comparisonMode;
+  }
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    String presentedApiKey = request.getHeader(HEADER_API_KEY);
+    String apiKeyId = request.getHeader(HEADER_API_KEY_ID);
+
+    if (presentedApiKey == null || presentedApiKey.isEmpty()) {
+      detailLog.warn("Request to " + request.getRequestURI() + " is missing the " + HEADER_API_KEY
+          + " header.");
+      reject(response);
+      return;
+    }
+
+    if (expectedValueProvider == null) {
+      detailLog.warn("A request reached " + request.getRequestURI() + " but no "
+          + "SplibBuiltinApiKeyExpectedValueProvider bean is registered, so it is being "
+          + "rejected. Register a bean implementing SplibBuiltinApiKeyExpectedValueProvider to "
+          + "accept requests under /api/ecuacion-splib/key/**.");
+      reject(response);
+      return;
+    }
+
+    Collection<String> expectedValues = Objects.requireNonNull(expectedValueProvider)
+        .getExpectedValues(apiKeyId, presentedApiKey);
+    if (expectedValues == null || expectedValues.isEmpty()
+        || !matchesAny(presentedApiKey, expectedValues)) {
+      detailLog.warn("apiKey mismatch on request to " + request.getRequestURI() + ".");
+      reject(response);
+      return;
+    }
+
+    UsernamePasswordAuthenticationToken authentication = UsernamePasswordAuthenticationToken
+        .authenticated(apiKeyId != null ? apiKeyId : "builtin-api-key-client", null,
+            List.of(new SimpleGrantedAuthority(API_KEY_AUTHORITY)));
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+
+    filterChain.doFilter(request, response);
+  }
+
+  /**
+   * Checks {@code presentedApiKey} against every value in {@code expectedValues}, always
+   * comparing against all of them (never short-circuiting on the first match) so that the total
+   * comparison time does not itself hint at which entry — or how many entries — matched.
+   */
+  private boolean matchesAny(String presentedApiKey, Collection<String> expectedValues) {
+    String comparisonValue =
+        comparisonMode == SplibApiKeyComparisonMode.HASH ? sha256Hex(presentedApiKey)
+            : presentedApiKey;
+    byte[] comparisonBytes = comparisonValue.getBytes(StandardCharsets.UTF_8);
+
+    // MessageDigest.isEqual() is used instead of String.equals() to avoid a timing attack.
+    boolean matched = false;
+    for (String expectedValue : expectedValues) {
+      if (MessageDigest.isEqual(comparisonBytes, expectedValue.getBytes(StandardCharsets.UTF_8))) {
+        matched = true;
+      }
+    }
+
+    return matched;
+  }
+
+  private String sha256Hex(String value) {
+    MessageDigest digest;
+    try {
+      digest = MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException ex) {
+      // SHA-256 is guaranteed to be available on every conforming JDK.
+      throw new AssertionError(ex);
+    }
+
+    byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+    StringBuilder hex = new StringBuilder(hash.length * 2);
+    for (byte b : hash) {
+      hex.append(String.format("%02x", b));
+    }
+    return hex.toString();
+  }
+
+  private void reject(HttpServletResponse response) throws IOException {
+    response.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+        "Invalid or missing " + HEADER_API_KEY + ".");
+  }
+}

--- a/ecuacion-splib-rest/src/main/java/jp/ecuacion/splib/rest/apikey/SplibBuiltinApiKeyExpectedValueProvider.java
+++ b/ecuacion-splib-rest/src/main/java/jp/ecuacion/splib/rest/apikey/SplibBuiltinApiKeyExpectedValueProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2012 ecuacion.jp (info@ecuacion.jp)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.ecuacion.splib.rest.apikey;
+
+import java.util.Collection;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Supplies the expected values to compare a client-presented {@code X-Api-Key} header against,
+ * for {@code ecuacion-splib}'s own built-in endpoints mapped under
+ * {@code /api/ecuacion-splib/key/**} (e.g. {@code SystemErrorController},
+ * {@code ClearPropertiesCacheController}).
+ *
+ * <p>This is deliberately a separate type from {@link SplibApiKeyExpectedValueProvider}, which
+ *     backs the application's own {@code /api/key/**} namespace, so that the two key sets
+ *     (and the {@code jp.ecuacion.splib.rest.builtin-api-key.mode} comparison mode selecting
+ *     plain-text vs. hashed comparison for this one) are registered and rotated independently.
+ *     If no bean of this type is registered, every request to
+ *     {@code /api/ecuacion-splib/key/**} is rejected.</p>
+ *
+ * <p>More than one valid value can be returned — e.g. one per issued token — so that a single
+ *     leaked or retired key can be dropped without invalidating the others. Where the values come
+ *     from (fixed values in {@code application.properties}, rows in a database, ...) is entirely
+ *     up to the implementation; splib only calls {@link #getExpectedValues} and accepts the
+ *     request if {@code presentedApiKey} matches any of the returned values.</p>
+ */
+public interface SplibBuiltinApiKeyExpectedValueProvider {
+
+  /**
+   * Returns the values to compare {@code presentedApiKey} against; the request is authenticated
+   * if it matches any of them. Return {@code null} or an empty collection if no match can be
+   * determined — the request is then rejected the same way a mismatched value would be, so a
+   * caller cannot distinguish "no such key" from "wrong key".
+   *
+   * <p>Whether the returned values (and the comparison itself) are treated as plain text or as a
+   *     SHA-256 hash is controlled application-wide by
+   *     {@code jp.ecuacion.splib.rest.builtin-api-key.mode}; see {@link SplibApiKeyComparisonMode}.
+   *     </p>
+   *
+   * @param apiKeyId the {@code X-Api-Key-Id} header value, or {@code null} if the client did not
+   *     send one. Present so a per-client key scheme can be implemented — an identifier used to
+   *     look up which record's expected value(s) to check, analogous to an AWS access key ID or
+   *     an HTTP Basic username, sent alongside the secret rather than derived from it. An
+   *     implementation that accepts any of a shared pool of keys regardless of who is calling can
+   *     simply ignore this parameter.
+   * @param presentedApiKey the {@code X-Api-Key} header value the client sent; never {@code null}
+   *     or empty (already checked before this method is called)
+   * @return the values to compare {@code presentedApiKey} against, or {@code null} to reject the
+   *     request
+   */
+  @Nullable
+  Collection<String> getExpectedValues(@Nullable String apiKeyId, String presentedApiKey);
+}

--- a/ecuacion-splib-rest/src/main/java/jp/ecuacion/splib/rest/config/SplibRestSecurityConfig.java
+++ b/ecuacion-splib-rest/src/main/java/jp/ecuacion/splib/rest/config/SplibRestSecurityConfig.java
@@ -19,6 +19,8 @@ package jp.ecuacion.splib.rest.config;
 import jp.ecuacion.splib.rest.apikey.SplibApiKeyAuthenticationFilter;
 import jp.ecuacion.splib.rest.apikey.SplibApiKeyComparisonMode;
 import jp.ecuacion.splib.rest.apikey.SplibApiKeyExpectedValueProvider;
+import jp.ecuacion.splib.rest.apikey.SplibBuiltinApiKeyAuthenticationFilter;
+import jp.ecuacion.splib.rest.apikey.SplibBuiltinApiKeyExpectedValueProvider;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -38,8 +40,14 @@ public abstract class SplibRestSecurityConfig {
   @Nullable
   private final SplibApiKeyExpectedValueProvider apiKeyExpectedValueProvider;
 
+  @Nullable
+  private final SplibBuiltinApiKeyExpectedValueProvider builtinApiKeyExpectedValueProvider;
+
   @Value("${jp.ecuacion.splib.rest.api-key.mode:PLAIN}")
   private SplibApiKeyComparisonMode apiKeyComparisonMode = SplibApiKeyComparisonMode.PLAIN;
+
+  @Value("${jp.ecuacion.splib.rest.builtin-api-key.mode:PLAIN}")
+  private SplibApiKeyComparisonMode builtinApiKeyComparisonMode = SplibApiKeyComparisonMode.PLAIN;
 
   /**
    * Constructs a new instance.
@@ -48,10 +56,16 @@ public abstract class SplibRestSecurityConfig {
    *     {@code /api/key/**} authentication, or {@code null} if the application does not use
    *     that prefix — every request to it is then rejected; see
    *     {@link SplibApiKeyExpectedValueProvider}
+   * @param builtinApiKeyExpectedValueProvider the application-supplied provider backing
+   *     {@code /api/ecuacion-splib/key/**} authentication, or {@code null} if the application
+   *     does not use that prefix — every request to it is then rejected; see
+   *     {@link SplibBuiltinApiKeyExpectedValueProvider}
    */
   protected SplibRestSecurityConfig(
-      @Nullable SplibApiKeyExpectedValueProvider apiKeyExpectedValueProvider) {
+      @Nullable SplibApiKeyExpectedValueProvider apiKeyExpectedValueProvider,
+      @Nullable SplibBuiltinApiKeyExpectedValueProvider builtinApiKeyExpectedValueProvider) {
     this.apiKeyExpectedValueProvider = apiKeyExpectedValueProvider;
+    this.builtinApiKeyExpectedValueProvider = builtinApiKeyExpectedValueProvider;
   }
 
   /**
@@ -81,10 +95,13 @@ public abstract class SplibRestSecurityConfig {
    *     stops a {@code @PostMapping} from being added under {@code /api/public/**}; it is a
    *     convention this class assumes but cannot itself enforce.</p>
    *
-   * <p>{@code /api/ecuacion-splib/public/**} carries 
+   * <p>{@code /api/ecuacion-splib/public/**} carries
    *     the same {@code permitAll} policy but is reserved
-   *     for {@code ecuacion-splib}'s own built-in endpoints (e.g. {@code AliveCheckController}), so
-   *     that {@code /api/public/**} stays exclusively the application's own namespace.</p>
+   *     for {@code ecuacion-splib}'s own built-in endpoints that are safe to expose without
+   *     authentication (e.g. {@code AliveCheckController}), so that {@code /api/public/**} stays
+   *     exclusively the application's own namespace. Built-in endpoints with side effects (e.g.
+   *     {@code SystemErrorController}) instead live under {@code /api/ecuacion-splib/key/**}; see
+   *     {@link #filterChainForApiEcuacionSplibKey}.</p>
    *
    * <p>CSRF is disabled here because it only matters when a forged cross-site request can ride
    *     on a credential the browser attaches automatically (e.g. a session cookie) to act on an
@@ -156,13 +173,55 @@ public abstract class SplibRestSecurityConfig {
   }
 
   /**
-   * Provides SecurityFilterChain.
+   * Provides SecurityFilterChain requiring {@code X-Api-Key} authentication for
+   * {@code ecuacion-splib}'s own built-in endpoints (e.g. {@code SystemErrorController},
+   * {@code ClearPropertiesCacheController}).
+   *
+   * <p>See {@link SplibBuiltinApiKeyExpectedValueProvider} for how the expected value is
+   *     supplied, and {@link SplibApiKeyComparisonMode} for the
+   *     {@code jp.ecuacion.splib.rest.builtin-api-key.mode} property selecting plain-text vs.
+   *     hashed comparison. This key set is independent of {@link #filterChainForApiKey}'s
+   *     {@code /api/key/**} keys — the two are registered and rotated separately.</p>
+   *
+   * <p>CSRF is disabled here for the same reason as {@link #filterChainForApiKey}: {@code
+   *     X-Api-Key} is not a credential the browser attaches automatically, so there is nothing
+   *     for CSRF protection to add.</p>
    *
    * @param http http
    * @return SecurityFilterChain
    * @throws Exception Exception
    */
   @Order(10)
+  @Bean
+  SecurityFilterChain filterChainForApiEcuacionSplibKey(HttpSecurity http) throws Exception {
+    http.securityMatcher("/api/ecuacion-splib/key/**");
+
+    http.httpBasic(basic -> basic.disable());
+    http.csrf(csrf -> csrf.disable());
+
+    http.addFilterBefore(
+        new SplibBuiltinApiKeyAuthenticationFilter(
+            builtinApiKeyExpectedValueProvider, builtinApiKeyComparisonMode),
+        UsernamePasswordAuthenticationFilter.class);
+
+    // The filter above already rejects (401) any request that fails API-key authentication, so
+    // authorization here only needs to admit requests that got past it.
+    http.authorizeHttpRequests(requests -> requests
+        .requestMatchers(
+            PathPatternRequestMatcher.withDefaults().matcher("/api/ecuacion-splib/key/**"))
+        .permitAll());
+
+    return http.build();
+  }
+
+  /**
+   * Provides SecurityFilterChain.
+   *
+   * @param http http
+   * @return SecurityFilterChain
+   * @throws Exception Exception
+   */
+  @Order(11)
   @Bean
   SecurityFilterChain filterChainForApi(HttpSecurity http) throws Exception {
     // MvcRequestMatcher.Builder mvc = new MvcRequestMatcher.Builder(introspector);

--- a/ecuacion-splib-rest/src/main/java/jp/ecuacion/splib/rest/controller/ClearPropertiesCacheController.java
+++ b/ecuacion-splib-rest/src/main/java/jp/ecuacion/splib/rest/controller/ClearPropertiesCacheController.java
@@ -16,15 +16,14 @@
 package jp.ecuacion.splib.rest.controller;
 
 import jp.ecuacion.lib.core.util.PropertiesFileUtil;
-import jp.ecuacion.splib.rest.exception.HttpStatusException;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Provides a controller that clears the {@code PropertiesFileUtil} cache.
  *
- * <p>Mapped under {@code /api/ecuacion-splib/public/**}; see {@code AliveCheckController}.</p>
+ * <p>Mapped under {@code /api/ecuacion-splib/key/**}, so it requires {@code X-Api-Key}
+ *     authentication; see {@code SplibBuiltinApiKeyExpectedValueProvider}.</p>
  */
 @RestController
 public class ClearPropertiesCacheController {
@@ -32,23 +31,9 @@ public class ClearPropertiesCacheController {
   /**
    * Clears the cache of properties files read via {@code PropertiesFileUtil},
    * so that changes to application.properties can be picked up without restarting the app.
-   *
-   * <p>Rejected unless {@code jp.ecuacion.splib.rest.ecuacion-config-endpoints.enabled}
-   *     is set to {@code true} in application.properties.</p>
-   *
-   * @throws HttpStatusException if the endpoint is not enabled
    */
-  @PostMapping("/api/ecuacion-splib/public/clearPropertiesCache")
-  public void clearPropertiesCache() throws HttpStatusException {
-    checkConfigEndpointsEnabled();
-
+  @PostMapping("/api/ecuacion-splib/key/clearPropertiesCache")
+  public void clearPropertiesCache() {
     PropertiesFileUtil.clearCache();
-  }
-
-  private void checkConfigEndpointsEnabled() throws HttpStatusException {
-    if (!Boolean.parseBoolean(PropertiesFileUtil.getApplicationOrElse(
-        "jp.ecuacion.splib.rest.ecuacion-config-endpoints.enabled", "false"))) {
-      throw new HttpStatusException(HttpStatus.FORBIDDEN);
-    }
   }
 }

--- a/ecuacion-splib-rest/src/main/java/jp/ecuacion/splib/rest/controller/SystemErrorController.java
+++ b/ecuacion-splib-rest/src/main/java/jp/ecuacion/splib/rest/controller/SystemErrorController.java
@@ -15,16 +15,14 @@
  */
 package jp.ecuacion.splib.rest.controller;
 
-import jp.ecuacion.lib.core.util.PropertiesFileUtil;
-import jp.ecuacion.splib.rest.exception.HttpStatusException;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Provides a controller that deliberately causes a system error.
  *
- * <p>Mapped under {@code /api/ecuacion-splib/public/**}; see {@code AliveCheckController}.</p>
+ * <p>Mapped under {@code /api/ecuacion-splib/key/**}, so it requires {@code X-Api-Key}
+ *     authentication; see {@code SplibBuiltinApiKeyExpectedValueProvider}.</p>
  */
 @RestController
 public class SystemErrorController {
@@ -32,23 +30,9 @@ public class SystemErrorController {
   /**
    * Deliberately throws a system error so that the system error behavior
    * (exception handling, logging, and so on) can be tested without requiring an actual bug.
-   *
-   * <p>Rejected unless {@code jp.ecuacion.splib.rest.ecuacion-config-endpoints.enabled}
-   *     is set to {@code true} in application.properties.</p>
-   *
-   * @throws HttpStatusException if the endpoint is not enabled
    */
-  @PostMapping("/api/ecuacion-splib/public/systemError")
-  public void systemError() throws HttpStatusException {
-    checkConfigEndpointsEnabled();
-
+  @PostMapping("/api/ecuacion-splib/key/systemError")
+  public void systemError() {
     throw new RuntimeException("A system error was intentionally caused for testing purposes.");
-  }
-
-  private void checkConfigEndpointsEnabled() throws HttpStatusException {
-    if (!Boolean.parseBoolean(PropertiesFileUtil.getApplicationOrElse(
-        "jp.ecuacion.splib.rest.ecuacion-config-endpoints.enabled", "false"))) {
-      throw new HttpStatusException(HttpStatus.FORBIDDEN);
-    }
   }
 }


### PR DESCRIPTION
- /api/ecuacion-splib/key path added
- ClearPropertiesCacheController and SystemErrorController changed their paths to /api/ecuacion-splib/key
- jp.ecuacion.splib.rest.ecuacion-config-endpoints.enabled parameter removed because it's unneeded anymore
